### PR TITLE
Improved image names & README Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
+  workflow_dispatch:
+  
 env:
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,9 @@ jobs:
         with:
           containerfiles: |
             ./Containerfile
-          image: ${{ matrix.image_name }}
+          # Postfix image name with -nvidia to make it a little more descriptive
+          # Syntax: https://docs.github.com/en/actions/learn-github-actions/expressions#format
+          image: ${{ format('{0}-nvidia', matrix.image_name) }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
             ${{ steps.generate-tags.outputs.date }}
@@ -132,7 +134,7 @@ jobs:
 
       - name: Sign container image
         run: |
-          cosign sign --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image_name }}@${TAGS}
+          cosign sign --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosi
 
     cosign verify --key cosign.pub ghcr.io/ublue-os/base
     
-If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/overview/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions.
+If you're forking this repo you should [read the docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets) on keeping secrets in github. You need to [generate a new keypair](https://docs.sigstore.dev/cosign/overview/) with cosign. The public key can be in your public repo (your users need it to check the signatures), and you can paste the private key in Settings -> Secrets -> Actions with the name SIGNING_SECRET.
 
 ## Building locally
 
@@ -65,6 +65,8 @@ If you're forking this repo you should [read the docs](https://docs.github.com/e
 ```
 $ ./generate-akmod-key
 ```
+
+    If you are forking this repo, you also need to add the private key to the repository secrets under the name AKMOD_PRIVKEY.
 
 2. Build container
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
    Any system running `rpm-ostree` should be able to rebase onto one of the images built in this project:
 
-       rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/nvidia:latest
-    
+    Silverblue:  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest```
+
+    Kinoite:  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/kinoite-nvidia:latest```
+
    And then reboot.
 
 2. Set kargs after rebasing


### PR DESCRIPTION
* The two image names are postfixed with "-nvidia" in build.yml for more clarity
* The README now mentions the new images and not the one simply called "nvidia" as after #26 it is no longer updated.

Note: Build not properly tested as my repository is not configured correctly. I'm trusting that the on: pull_request: trigger will test building this. I believe the build will succeed with proper configuration, as only the image name (and one line which depended on it) has been changed in build.yml with code I did verify working.