### PR TITLE
Add tons more images, misc docs updates.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: [silverblue, kinoite, vauxite, sericea, base]
-        major_version: [37, 38]
+        major_version: [37]
         driver_version: [525]
         include:
           - major_version: 37
@@ -39,6 +39,7 @@ jobs:
             is_stable: true
         exclude:
           # There is no Fedora 37 version of sericea
+          # When F38 is added, sericea will automatically be built too
           - image_name: sericea
             major_version: 37
     steps: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: [silverblue, kinoite, vauxite, sericea, base]
-        major_version: [37]
+        major_version: [37, 38]
         driver_version: [525]
         include:
           - major_version: 37
@@ -37,6 +37,10 @@ jobs:
           - driver_version: 525
             is_latest: true
             is_stable: true
+        exclude:
+          # There is no Fedora 37 version of sericea
+          - image_name: sericea
+            major_version: 37
     steps: 
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_name: [silverblue, kinoite, vauxite]
+        image_name: [silverblue, kinoite, vauxite, sericea, base]
         major_version: [37]
         driver_version: [525]
         include:

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN rpm-ostree install \
 
 # nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
 # package names
-RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
+RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 && "${FEDORA_MAJOR_VERSION}" -ne 38 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
 
 RUN rpm-ostree install \
         akmods \

--- a/Containerfile
+++ b/Containerfile
@@ -35,7 +35,7 @@ RUN chmod 644 /etc/pki/akmods/{private/private_key.priv,certs/public_key.der}
 # Either successfully build and install the kernel modules, or fail early with debug output
 RUN NVIDIA_PACKAGE_NAME="$(cat /tmp/nvidia-package-name.txt)" \
     KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
-    NVIDIA_VERSION="$(basename "$(rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" --queryformat '%{VERSION}-%{RELEASE}')" ".fc$(rpm -E '%fedora')")" \
+    NVIDIA_VERSION="$(basename "$(rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" --queryformat '%{VERSION}-%{RELEASE}')")" \
     && \
         echo $NVIDIA_VERSION && akmods --force --kernels "${KERNEL_VERSION}" --kmod "${NVIDIA_PACKAGE_NAME}" \
     && \
@@ -63,7 +63,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 COPY --from=builder /var/cache/akmods      /tmp/akmods
 COPY --from=builder /tmp/akmods-nvidia-key /tmp/akmods-nvidia-key
 
-RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}.%{ARCH}')" \
+RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
     NVIDIA_FULL_VERSION="$(cat /tmp/akmods/nvidia-full-version.txt)" \
     NVIDIA_PACKAGE_NAME="$(cat /tmp/akmods/nvidia-package-name.txt)" \
     && \

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]; then echo "nvidia"; else echo "nvi
 RUN rpm-ostree install \
         akmods \
         mock \
-        xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc$(rpm -E '%fedora.%_arch')  \
+        xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.$(rpm -E '%_arch')  \
         binutils \
         kernel-devel-$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 

--- a/Containerfile
+++ b/Containerfile
@@ -56,7 +56,7 @@ RUN rpmbuild -ba \
 RUN cp /tmp/nvidia-package-name.txt /var/cache/akmods/nvidia-package-name.txt
 RUN echo "${NVIDIA_MAJOR_VERSION}" > /var/cache/akmods/nvidia-major-version.txt
 RUN rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" \
-    --queryformat '%{EPOCH}:%{VERSION}.%{ARCH}' > /var/cache/akmods/nvidia-full-version.txt
+    --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}' > /var/cache/akmods/nvidia-full-version.txt
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN rpm-ostree install \
 
 # nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
 # package names
-RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ] && [ "${FEDORA_MAJOR_VERSION}" -ne 38 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
+RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
 
 RUN rpm-ostree install \
         akmods \

--- a/Containerfile
+++ b/Containerfile
@@ -63,7 +63,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 COPY --from=builder /var/cache/akmods      /tmp/akmods
 COPY --from=builder /tmp/akmods-nvidia-key /tmp/akmods-nvidia-key
 
-RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
+RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}.%{ARCH}')" \
     NVIDIA_FULL_VERSION="$(cat /tmp/akmods/nvidia-full-version.txt)" \
     NVIDIA_PACKAGE_NAME="$(cat /tmp/akmods/nvidia-package-name.txt)" \
     && \

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]; then echo "nvidia"; else echo "nvi
 RUN rpm-ostree install \
         akmods \
         mock \
-        xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.$(rpm -E '%_arch')  \
+        xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc$(rpm -E '%fedora.%_arch')  \
         binutils \
         kernel-devel-$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 
@@ -35,7 +35,7 @@ RUN chmod 644 /etc/pki/akmods/{private/private_key.priv,certs/public_key.der}
 # Either successfully build and install the kernel modules, or fail early with debug output
 RUN NVIDIA_PACKAGE_NAME="$(cat /tmp/nvidia-package-name.txt)" \
     KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
-    NVIDIA_VERSION="$(basename "$(rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" --queryformat '%{VERSION}-%{RELEASE}')")" \
+    NVIDIA_VERSION="$(basename "$(rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" --queryformat '%{VERSION}-%{RELEASE}')" ".fc$(rpm -E '%fedora')")" \
     && \
         echo $NVIDIA_VERSION && akmods --force --kernels "${KERNEL_VERSION}" --kmod "${NVIDIA_PACKAGE_NAME}" \
     && \
@@ -62,9 +62,6 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 
 COPY --from=builder /var/cache/akmods      /tmp/akmods
 COPY --from=builder /tmp/akmods-nvidia-key /tmp/akmods-nvidia-key
-
-# debug print to see actual names of created files
-RUN ls /tmp/akmods/nvidia/
 
 RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
     NVIDIA_FULL_VERSION="$(cat /tmp/akmods/nvidia-full-version.txt)" \

--- a/Containerfile
+++ b/Containerfile
@@ -63,6 +63,9 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 COPY --from=builder /var/cache/akmods      /tmp/akmods
 COPY --from=builder /tmp/akmods-nvidia-key /tmp/akmods-nvidia-key
 
+# debug print to see actual names of created files
+RUN ls /tmp/akmods/nvidia/
+
 RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')" \
     NVIDIA_FULL_VERSION="$(cat /tmp/akmods/nvidia-full-version.txt)" \
     NVIDIA_PACKAGE_NAME="$(cat /tmp/akmods/nvidia-package-name.txt)" \

--- a/Containerfile
+++ b/Containerfile
@@ -56,7 +56,7 @@ RUN rpmbuild -ba \
 RUN cp /tmp/nvidia-package-name.txt /var/cache/akmods/nvidia-package-name.txt
 RUN echo "${NVIDIA_MAJOR_VERSION}" > /var/cache/akmods/nvidia-major-version.txt
 RUN rpm -q "xorg-x11-drv-$(cat /tmp/nvidia-package-name.txt)" \
-    --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}' > /var/cache/akmods/nvidia-full-version.txt
+    --queryformat '%{EPOCH}:%{VERSION}.%{ARCH}' > /var/cache/akmods/nvidia-full-version.txt
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
 

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ RUN rpm-ostree install \
 
 # nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
 # package names
-RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 && "${FEDORA_MAJOR_VERSION}" -ne 38 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
+RUN if [ "${NVIDIA_MAJOR_VERSION}" -ge 520 ] && [ "${FEDORA_MAJOR_VERSION}" -ne 38 ]; then echo "nvidia"; else echo "nvidia-${NVIDIA_MAJOR_VERSION}xx"; fi > /tmp/nvidia-package-name.txt
 
 RUN rpm-ostree install \
         akmods \

--- a/README.md
+++ b/README.md
@@ -14,11 +14,20 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
    Note: The image previously titled "nvidia" will not be updated anymore. If you wish to retain the same functionality, switch to "silverblue-nvidia".
 
-    Silverblue:  
+    Silverblue (GNOME):  
         ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest```
 
-    Kinoite:  
+    Kinoite (KDE):  
         ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/kinoite-nvidia:latest```
+
+    Vauxite (XFCE, unofficial):  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/vauxite-nvidia:latest```
+
+    Sericea (Sway):  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:latest```
+
+    Base (no DE preinstalled):  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/base-nvidia:latest```
 
    And then reboot.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The purpose of these images is to provide builds of vanilla Fedora with Nvidia drivers built-in. This approach can lead to greater reliability as failures can be caught at the build level instead of the client machine. This also lets us generate individual sets of images for each series of Nvidia drivers, allowing users to remain current with their OS but on an older, known working driver. Performance regression with a recent driver update? Reboot into a known-working driver after one command. That's the goal!
 
+These images are based on the experimental ostree native container images hosted at [quay.io](https://quay.io/organization/fedora-ostree-desktops) ([repo](https://gitlab.com/fedora/ostree/ci-test)).
+
 Note: This project is a work-in-progress. You should at a minimum be familiar with the [Fedora documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/) on how to administer an ostree system. This is currently for people who want to help figure this out, so there may be explosions and gnashing of teeth. 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
    Note: The image previously titled "nvidia" will not be updated anymore. If you wish to retain the same functionality, switch to "silverblue-nvidia".
 
-   Note: Fedora 38 *beta* builds are now available under the tag 38.
-
     Silverblue (GNOME):  
     ```
     rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest
@@ -33,15 +31,12 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
     rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/vauxite-nvidia:latest
     ```
 
-    Sericea (Sway, Fedora 37 unavailable):  
-    ```
-    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:38
-    ```
-
     Base (no DE preinstalled):  
     ```
     rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/base-nvidia:latest
     ```
+
+    Sericea will be made available when there is a functioning Fedora 38 build.
 
    And then reboot.
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,29 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
    Note: Fedora 38 *beta* builds are now available under the tag 38.
 
     Silverblue (GNOME):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest```
+    ```
+    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest
+    ```
 
     Kinoite (KDE):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/kinoite-nvidia:latest```
+    ```
+    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/kinoite-nvidia:latest
+    ```
 
     Vauxite (XFCE, unofficial):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/vauxite-nvidia:latest```
+    ```
+    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/vauxite-nvidia:latest
+    ```
 
     Sericea (Sway, Fedora 37 unavailable):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:38```
+    ```
+    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:38
+    ```
 
     Base (no DE preinstalled):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/base-nvidia:latest```
+    ```
+    rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/base-nvidia:latest
+    ```
 
    And then reboot.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
    Note: The image previously titled "nvidia" will not be updated anymore. If you wish to retain the same functionality, switch to "silverblue-nvidia".
 
+   Note: Fedora 38 *beta* builds are now available under the tag 38.
+
     Silverblue (GNOME):  
         ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-nvidia:latest```
 
@@ -23,8 +25,8 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
     Vauxite (XFCE, unofficial):  
         ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/vauxite-nvidia:latest```
 
-    Sericea (Sway):  
-        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:latest```
+    Sericea (Sway, Fedora 37 unavailable):  
+        ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/sericea-nvidia:38```
 
     Base (no DE preinstalled):  
         ```rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/base-nvidia:latest```


### PR DESCRIPTION
I added all of the images @ https://quay.io/organization/fedora-ostree-desktops except for beta and buildroot.
Docs rebasing section also reformatted to be the same way as other code blocks. 
Fedora 38 builds are added, so when it releases only docs have to be changed. F37 is still marked as "stable" and "latest", so that nobody unintentionally rebases to F38.

Also: Conventional commits!