### PR TITLE
fix: use full image title and updated description for labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,8 @@ jobs:
           images: |
             ${{ format('{0}-nvidia', matrix.image_name) }}
           labels: |
+            org.opencontainers.image.title=${{ format('{0}-nvidia', matrix.image_name) }}
+            org.opencontainers.image.description=Vanilla $${{ matrix.image_name }} with Nvidia drivers added
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/base/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
       # Build image using Buildah action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
             ${{ format('{0}-nvidia', matrix.image_name) }}
           labels: |
             org.opencontainers.image.title=${{ format('{0}-nvidia', matrix.image_name) }}
-            org.opencontainers.image.description=Vanilla $${{ matrix.image_name }} with Nvidia drivers added
+            org.opencontainers.image.description=Vanilla ${{ matrix.image_name }} with Nvidia drivers added
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/base/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
       # Build image using Buildah action


### PR DESCRIPTION
Fixes the image listings all showing as nvidia and "Vanilla SilverBlue with Nvidia Drivers"