### PR TITLE
feat: Add vaapi packages to enable hardware-accelerated playback

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -86,20 +86,37 @@ RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}
             https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
             https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
     && \
-        sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion-free{,-updates}.repo \
-    && \
         rpm-ostree install \
             xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda-,devel-,kmodsrc-,power-}${NVIDIA_FULL_VERSION} \
             kernel-devel-${KERNEL_VERSION} nvidia-container-toolkit \
             "/tmp/akmods/${NVIDIA_PACKAGE_NAME}/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_FULL_VERSION#*:}.rpm" \
             /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons-*.rpm \
     && \
+        rpm-ostree override remove $(rpm -qa --queryformat='%{NAME} ' \
+            mesa-va-drivers \
+            libavutil-free \
+            libswscale-free \
+            libswresample-free \
+            libavformat-free \
+            libavcodec-free \
+            libavfilter-free \
+            libavdevice-free \
+            libpostproc-free) \
+            --install=mesa-va-drivers-freeworld \
+            --install=mesa-vdpau-drivers-freeworld \
+            --install=libva-intel-driver \
+            --install=nvidia-vaapi-driver \
+            --install=ffmpeg-libs \
+            --install=ffmpeg \
+            --install=libavcodec-freeworld \
+            --install=libva-utils \
+    && \
         mv /etc/nvidia-container-runtime/config.toml{,.orig} && \
         cp /etc/nvidia-container-runtime/config{-rootless,}.toml \
     && \
         semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp \
     && \
-        sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion-nonfree{,-updates}.repo \
+        sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion-{,non}free{,-updates}.repo \
     && \
         ln -s /usr/bin/ld.bfd /etc/alternatives/ld && \
         ln -s /etc/alternatives/ld /usr/bin/ld \

--- a/Containerfile
+++ b/Containerfile
@@ -105,6 +105,7 @@ RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}
             --install=mesa-va-drivers-freeworld \
             --install=mesa-vdpau-drivers-freeworld \
             --install=libva-intel-driver \
+            --install=nvtop \
             --install=nvidia-vaapi-driver \
             --install=ffmpeg-libs \
             --install=ffmpeg \

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ $ podman run \
     docker.io/mirrorgooglecontainers/cuda-vector-add:v0.1
 ```
 
+## Video playback
+
+Additional runtime packages are added for enabling hardware-accelerated video playback. [Some additional configuration may be needed to enable support in flatpak](https://github.com/elFarto/nvidia-vaapi-driver/issues/23).
+
 ## Acknowledgements
 
 Thanks to Alex Diaz for advice, and who got this working first, check out this repo:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,25 @@ $ podman run \
 
 ## Video playback
 
-Additional runtime packages are added for enabling hardware-accelerated video playback. [Some additional configuration may be needed to enable support in flatpak](https://github.com/elFarto/nvidia-vaapi-driver/issues/23).
+Additional runtime packages are added for enabling hardware-accelerated video playback. This can the enabled in Firefox (RPM or flatpak) by setting the following options to `true` in `about:config`:
+
+* `gfx.webrender.all`
+* `media.ffmpeg.vaapi.enabled`
+
+
+Extensive host access and reduced sandboxing is needed for Firefox flatpak to use `/usr/lib64/dri/nvidia_drv_video.so`:
+
+```
+$ flatpak override \
+    --user \
+    --filesystem=host-os \
+    --env=LIBVA_DRIVER_NAME=nvidia \
+    --env=LIBVA_DRIVERS_PATH=/run/host/usr/lib64/dri \
+    --env=LIBVA_MESSAGING_LEVEL=1 \
+    --env=MOZ_DISABLE_RDD_SANDBOX=1 \
+    --env=NVD_BACKEND=direct \
+    org.mozilla.firefox
+```
 
 ## Acknowledgements
 


### PR DESCRIPTION
This change introduces more runtime support packages as part of https://github.com/ublue-os/nvidia/issues/35

Credit goes to: https://github.com/ublue-os/bazzite/blob/16b33c1047a049d24143c48359101067297e91b1/Containerfile#L48