### PR TITLE
fix: preserve /var/tmp for akmods builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -131,4 +131,7 @@ RUN KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}
             /tmp/* \
             /var/* \
     && \
-        ostree container commit
+        ostree container commit \
+    && \
+        mkdir -p /var/tmp && \
+        chmod -R 1777 /var/tmp


### PR DESCRIPTION
This PR fixes a problem I noticed when I switched my "custom kmod image" to be based on this nvidia image rather than the stock silverblue image.

## Problem 
akmods fail to build with message `Unable to open temp file: Permission denied"` if the `FROM` image is one of these ublue-os nvidia images.

## Explanation
The original silverblue image includes `/var/tmp` with normal sticky bit perms, while this image removes `/var`  as part of build cleanup.

The lack of `/var/tmp` causes rpmbuilds (eg, akmod builds) to fail on any container builds which use `ublue-os/nvidia` images as their base because the akmod build will create /var/tmp using the default umask (0022). `/var/tmp` then lacks proper permissions, and akmods fail to create a tmp dir for builds, since `/var/tmp` gets created by root, but `akmods` builds run as a user.

## Solution
Preserve `/var/tmp` with correct permissions.

The interesting thing is, I had assumed that the `rm -rf /var/*` was the cause of the problem, but,  `ostree container commit` actually removes `/var` from the image even when it still contains files.  


See the code blocks for contrast of `/var/tmp` filesystem state on the respective  images and `ostree container commit` behavior.

##### stock silverblue /var/tmp state
```bash
$ podman run --rm -ti  quay.io/fedora-ostree-desktops/silverblue:37 bash
bash-5.2# umask
0022
bash-5.2# ls -al /var
total 0
drwxr-xr-x. 1 root root  6 Jan  1  1970 .
dr-xr-xr-x. 1 root root 18 Feb 20 16:18 ..
drwxrwxrwt. 1 root root  0 Jan  1  1970 tmp
```

##### ublue-os/nvidia silverblue /var/tmp state
```bash
$ podman run --rm -ti ghcr.io/ublue-os/silverblue-nvidia:37 bash
bash-5.2# umask
0022
bash-5.2# ls -al /var
ls: cannot access '/var': No such file or directory
```

##### stock silverblue ostree container commit behavior
```bash
$ podman run --rm -ti  quay.io/fedora-ostree-desktops/silverblue:37 bash
bash-5.2# touch /var/tmp/preserve-me-ostree
bash-5.2# ls -al /var/tmp/
total 0
drwxrwxrwt. 1 root root 36 Feb 20 17:56 .
drwxr-xr-x. 1 root root  6 Jan  1  1970 ..
-rw-r--r--. 1 root root  0 Feb 20 17:56 preserve-me-ostree
bash-5.2# ostree container commit
bash-5.2# ls -al /var/tmp/
ls: cannot access '/var/tmp/': No such file or directory
```