### PR TITLE
fix: add cron delay to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - main
       - devel
   schedule:
-    - cron: '20 20 * * *'  # 8:20pm everyday
+    - cron: '20 21 * * *'  # 9:20pm everyday (1 hr delay after 'main' builds)
   push:
     branches:
       - main


### PR DESCRIPTION
Delaying the build by an hour to give `main` images a chance to complete before starting which allows nvidia builds to get the current main updates.