### PR TITLE
chore: have builders ignore text file changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,17 @@ on:
     branches:
       - main
       - devel
+    paths-ignore:
+      - '**.md'
+      - '**.txt'  
   schedule:
     - cron: '20 21 * * *'  # 9:20pm everyday (1 hr delay after 'main' builds)
   push:
     branches:
       - main
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
+      - '**.txt'
   workflow_dispatch:
   
 env:


### PR DESCRIPTION
We don't want builds kicking off when all we do is edit the text files.