### PR TITLE
fix: disable 520xx series due to broken compatibility in latest kernels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
         driver_version: [520, 525, 470]
         exclude:
           - driver_version: 520
+            major_version: 37
+          - driver_version: 520
             major_version: 38
           - driver_version: 470
             major_version: 38
@@ -206,6 +208,8 @@ jobs:
           # There is no Fedora 37 version of sericea
           # When F38 is added, sericea will automatically be built too
           - image_name: sericea
+            major_version: 37
+          - driver_version: 520
             major_version: 37
           - driver_version: 520
             major_version: 38

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
    Note: The Fedora release and Nvidia version can be set with the image tag as well:
 
-   |     | 525xx series                          | 520xx series  | 470xx series (Kepler 2012-2014 support) |
-   |-----|---------------------------------------|---------------|-----------------------------------------|
-   | F37 | :latest / :37 / :37-525 / :37-current | :37-520       | :37-470                                 |
-   | F38 | :38 / :38-525 / :38-current           |               |                                         |
+   |     | 525xx series (latest, best supported) | 520xx series (deprecated) | 470xx series (Kepler 2012-2014 support) |
+   |-----|---------------------------------------|---------------------------|-----------------------------------------|
+   | F37 | :latest / :37 / :37-525 / :37-current | :37-520                   | :37-470                                 |
+   | F38 | :38 / :38-525 / :38-current           |                           |                                         |
 
 2. Set kargs after rebasing
 


### PR DESCRIPTION
The nvidia 520xx series is currently broken on Linux 6.2.x kernels, which prevents new builds from being published. This change disables building for that series for now.