### PR TITLE
fix: maintain oci image version from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,14 @@ jobs:
           fi
           # DEBUG: get character count of key
           wc -c certs/private_key.priv
-      
+
+      - name: Get current version
+        id: labels
+        run: |
+          docker pull ghcr.io/ublue-os/${{ matrix.image_name }}-main:${{ matrix.major_version }}
+          ver=$(docker inspect ghcr.io/ublue-os/${{ matrix.image_name }}-main:${{ matrix.major_version }} | jq -r '.[].Config.Labels["org.opencontainers.image.version"]')
+          echo "VERSION=$ver" >> $GITHUB_OUTPUT
+
       # Build metadata
       - name: Image Metadata
         uses: docker/metadata-action@v4
@@ -307,6 +314,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.description=ublue-os ${{ matrix.image_name }} with Nvidia drivers added
+            org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
       # Build image using Buildah action


### PR DESCRIPTION
See ublue-os/main#88 for more details