### PR TITLE
chore(ci): remove path-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build-ublue
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   merge_group:    
   schedule:
     - cron: '20 21 * * *'  # 9:20pm everyday (1 hr delay after 'main' builds)


### PR DESCRIPTION
It causes checks to never finish when PRing the readme so let's just build everything, yolo.