### PR TITLE
chore(ci): finish sign refactor and limit pr build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,13 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-  merge_group:    
+  merge_group:
   schedule:
     - cron: '20 21 * * *'  # 9:20pm everyday (1 hr delay after 'main' builds)
   workflow_dispatch:
-  
+
 env:
-    IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 jobs:
   build-akmods:
     name: Build akmods package
@@ -103,6 +103,7 @@ jobs:
             org.opencontainers.image.description=ublue-os ${{ env.IMAGE_NAME }} with akmods-nvidia packages pre-built
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -131,6 +132,7 @@ jobs:
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
+        if: github.event_name != 'pull_request'
         id: push
         env:
           REGISTRY_USER: ${{ github.actor }}
@@ -144,33 +146,27 @@ jobs:
           extra-args: |
             --disable-content-trust
 
-      # Sign container
-      - uses: sigstore/cosign-installer@v3.0.3
-
-      # Only needed when running `cosign sign` using a key
-      - name: Write signing key to disk
-        run: |
-          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
-          # DEBUG: get character count of key
-          wc -c cosign.key
-        env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Sign container
       - name: Sign container image
+        uses: sigstore/cosign-installer@v3.0.3
+        if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Echo outputs
+        if: github.event_name != 'pull_request'
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"
 
@@ -215,7 +211,7 @@ jobs:
             major_version: 38
           - driver_version: 470
             major_version: 38
-    steps: 
+    steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v3
@@ -236,7 +232,7 @@ jobs:
           BUILD_TAGS=()
 
           # Have tags for tracking builds during pull request
-          SHA_SHORT="$(git rev-parse --short HEAD)"
+          SHA_SHORT="${GITHUB_SHA::7}"
           COMMIT_TAGS+=("pr-${{ github.event.number }}-${VARIANT}")
           COMMIT_TAGS+=("${SHA_SHORT}-${VARIANT}")
 
@@ -316,6 +312,7 @@ jobs:
             org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image
@@ -346,6 +343,7 @@ jobs:
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
         id: push
+        if: github.event_name != 'pull_request'
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ github.token }}
@@ -358,32 +356,26 @@ jobs:
           extra-args: |
             --disable-content-trust
 
-      # Sign container
-      - uses: sigstore/cosign-installer@v3.0.3
-
-      # Only needed when running `cosign sign` using a key
-      - name: Write signing key to disk
-        run: |
-          echo "${{ env.COSIGN_PRIVATE_KEY }}" > cosign.key
-          # DEBUG: get character count of key
-          wc -c cosign.key
-        env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Sign container
       - name: Sign container image
+        uses: sigstore/cosign-installer@v3.0.3
+        if: github.event_name != 'pull_request'
         run: |
-          cosign sign -y --key cosign.key ${{ steps.registry_case.outputs.lowercase }}/${{ steps.build_image.outputs.image }}@${TAGS}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Echo outputs
+        if: github.event_name != 'pull_request'
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,8 +155,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Sign container
+      - uses: sigstore/cosign-installer@v3.0.3
+        if: github.event_name != 'pull_request'
+
       - name: Sign container image
-        uses: sigstore/cosign-installer@v3.0.3
         if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
@@ -365,8 +367,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Sign container
+      - uses: sigstore/cosign-installer@v3.0.3
+        if: github.event_name != 'pull_request'
+
       - name: Sign container image
-        uses: sigstore/cosign-installer@v3.0.3
         if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}


### PR DESCRIPTION
First attempt to copy "avoid subshell, sign image with env. var" to this repo was incomplete as this workflow has two distinct build jobs and the second one was missed.

This commit finishes the job, plus prevents the following steps from running in a PR, again, to match the main repo:
- login to GHCR
- push to GHCR
- sign image
- echo push outputs