### PR TITLE
chore(ci): build nvidia 1 hour after main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '0 9 * * *'  # 9:00am everyday (1 hr delay after future 'akmods' builds)
+    - cron: '0 8 * * *'  # 8:00am everyday (1 hr delay after 'main' builds)
   workflow_dispatch:
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
This just starts building nvidia sooner after main than we had previously configured as we chose to move akmods before main, not after.

This PR closes #72 