### PR TITLE
fix: Change bash shebang to use env

### DIFF
--- a/generate-akmods-key
+++ b/generate-akmods-key
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -oeux pipefail
 


### PR DESCRIPTION
This is required for NixOS, where `/usr/bin` contains nothing but `env`. The `sh` shebang does not need to be changed, since `sh` is still in `/bin` on NixOS (in fact, it's the ONLY thing in that directory).