### PR TITLE
fix: drop failing v530 driver build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         major_version: [37, 38]
-        driver_version: [470, 530, 535]
+        driver_version: [470, 535]
         exclude:
-          - driver_version: 470
+          - driver_version: 530
             major_version: 38
           - driver_version: 530
             major_version: 37

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Or to rebase onto a specific release, driver, and date:
 
 Note: The Fedora release and Nvidia version can be set with the image tag as well:
 
-   |     | 530xx series (latest, best supported) | 525xx series (deprecated) | 520xx series (deprecated) | 470xx series (Kepler 2012-2014 support) |
-   |-----|---------------------------------------|---------------------------|---------------------------|-----------------------------------------|
-   | F37 | :37 / :37-530 / :37-current | :37-525                   | :37-520                   | :37-470                                 |
-   | F38 | :latest / :38 / :38-530 / :38-current           | :38-525                   |                           |                                         |
+   |     | 535xx series (latest, best supported) | 530xx series (deprecated) | 470xx series (Kepler 2012-2014 support) |
+   |-----|---------------------------------------|---------------------------|-----------------------------------------|
+   | F37 | :37 / :37-535 / :37-current |                           | :37-470                                 |
+   | F38 | :latest / :38 / :38-535 / :38-current           | :38-530                   | :38-470                                 |
 
 It is *strongly encouraged* for you to subscribe to [the Nvidia driver announcements](https://github.com/orgs/ublue-os/discussions/categories/nvidia-driver-announcements?discussions_q=is%3Aopen+category%3A%22Nvidia+Driver+Announcements%22) section of the forums to keep up with the latest changes and news. 
 


### PR DESCRIPTION
- remove v530 from f38 (fails due to kernel 6.4)
- enable v470 on f38 (wasn't built previously)
- now f38 and f37 are both building v535 and v470
- update README to reflect current state (was out of date)