### PR TITLE
fix: Restore Fedora 37 supergfxctl support

### DIFF
--- a/build.Containerfile
+++ b/build.Containerfile
@@ -17,10 +17,8 @@ ADD ublue-os-nvidia-addons.spec /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addo
 
 ADD https://nvidia.github.io/nvidia-docker/rhel9.0/nvidia-docker.repo \
     /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-runtime.repo
-ADD https://copr.fedorainfracloud.org/coprs/lukenukem/asus-linux/repo/fedora-${FEDORA_MAJOR_VERSION}/lukenukem-asus-linux-fedora-${FEDORA_MAJOR_VERSION}.repo \
-    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/lukenukem-asus-linux.repo
-ADD https://copr.fedorainfracloud.org/coprs/jhyub/supergfxctl-plasmoid/repo/fedora-${FEDORA_MAJOR_VERSION}/jhyub-supergfxctl-plasmoid-fedora-${FEDORA_MAJOR_VERSION}.repo \
-    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/jhyub-supergfxctl-plasmoid.repo
+ADD https://copr.fedorainfracloud.org/coprs/eyecantcu/supergfxctl/repo/fedora-${FEDORA_MAJOR_VERSION}/eyecantcu-supergfxctl-fedora-${FEDORA_MAJOR_VERSION}.repo \
+    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/eyecantcu-supergfxctl.repo
 
 ADD https://nvidia.github.io/nvidia-docker/rhel9.0/nvidia-docker.repo \
     /etc/yum.repos.d/nvidia-container-runtime.repo

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,8 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular
 
 install -D /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-runtime.repo \
     /etc/yum.repos.d/nvidia-container-runtime.repo
-install -D /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/lukenukem-asus-linux.repo \
-    /etc/yum.repos.d/lukenukem-asus-linux.repo
-install -D /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/jhyub-supergfxctl-plasmoid.repo \
-    /etc/yum.repos.d/jhyub-supergfxctl-plasmoid.repo
+install -D /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/eyecantcu-supergfxctl.repo \
+    /etc/yum.repos.d/eyecantcu-supergfxctl.repo
 
 source /var/cache/akmods/nvidia-vars
 

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -1,5 +1,5 @@
 Name:           ublue-os-nvidia-addons
-Version:        0.7
+Version:        0.8
 Release:        1%{?dist}
 Summary:        Additional files for nvidia driver support
 
@@ -10,11 +10,10 @@ BuildArch:      noarch
 Supplements:    mokutil policycoreutils
 
 Source0:        nvidia-container-runtime.repo
-Source1:        lukenukem-asus-linux.repo
-Source2:        jhyub-supergfxctl-plasmoid.repo
-Source3:        config-rootless.toml
-Source4:        nvidia-container.pp
-Source5:        environment
+Source1:        eyecantcu-supergfxctl.repo
+Source2:        config-rootless.toml
+Source3:        nvidia-container.pp
+Source4:        environment
 
 %description
 Adds various runtime files for nvidia support.
@@ -26,34 +25,33 @@ Adds various runtime files for nvidia support.
 %build
 # Have different name for *.der in case kmodgenca is needed for creating more keys
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
-install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/lukenukem-asus-linux.repo
-install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/jhyub-supergfxctl-plasmoid.repo
-install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
-install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
-install -Dm0644 %{SOURCE5} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
 
-sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/{lukenukem-asus-linux,jhyub-supergfxctl-plasmoid,nvidia-container-runtime}.repo
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-runtime}.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
-install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/lukenukem-asus-linux.repo         %{buildroot}%{_sysconfdir}/yum.repos.d/lukenukem-asus-linux.repo
-install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/jhyub-supergfxctl-plasmoid.repo   %{buildroot}%{_sysconfdir}/yum.repos.d/jhyub-supergfxctl-plasmoid.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml %{buildroot}%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
 
 %files
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
-%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/lukenukem-asus-linux.repo
-%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/jhyub-supergfxctl-plasmoid.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
-%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/lukenukem-asus-linux.repo
-%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/jhyub-supergfxctl-plasmoid.repo
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
 %attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
 
 %changelog
+* Sat Aug 3 2023 RJ Trujillo <eyecantcu@pm.me> - 0.8
+- Add new copr for supergfxctl
+
 * Sat Jun 17 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.7
 - Remove MOK keys; now provided by ublue-os-akmods-addons
 


### PR DESCRIPTION
Since the asus-linux repo we had been using has dropped Fedora 37 support, this introduces a copr repo with support included.