### PR TITLE
docs: add disclaimer to remove `kmod-nvidia` and `akmod-nvidia`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
         rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/silverblue-main
 
+!!! warning
+
+    Ensure that the packages `kmod-nvidia` and/or `akmod-nvidia` are not installed on your system. These may break the build in graphics card drivers and you may end up with no output from your GPU.  
+    You can check for their presence with `rpm-ostree status`.
+
 ### 1. Rebase onto the image
 
 Any system running `rpm-ostree` should be able to rebase onto one of the images built in this project:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note: This project is a work-in-progress. You should at a minimum be familiar wi
 
 !!! warning
 
-    Ensure that the packages `kmod-nvidia` and/or `akmod-nvidia` are not installed on your system. These may break the build in graphics card drivers and you may end up with no output from your GPU.  
+    Ensure that the packages `kmod-nvidia` and/or `akmod-nvidia` are not installed on your system. These may break the built in graphics card drivers and you may end up with no output from your GPU.  
     You can check for their presence with `rpm-ostree status`.
 
 ### 1. Rebase onto the image


### PR DESCRIPTION
On my own machine, I've found that having `kmod-nvidia` or `akmod-nvidia` installed to provide nvidia drivers often breaks any installed driver and the OS will either default to nouveau or be unable to provide any graphics card output.

This PR provides a warning on the readme page for nvidia images for this behavior.