### PR TITLE
chore: revive nvidia builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,23 +19,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate]
+        image_name:
+          - silverblue
+          - kinoite
+          - sericea
+          - onyx
+          - base
+          - lxqt
+          - mate
+          - vauxite
+        #major_version: [37, 38, 39]
         major_version: [37, 38]
         driver_version: [470, 535]
         include:
           - major_version: 37
             is_latest_version: false
             is_stable_version: true
+            is_gts_driver: false
           - major_version: 38
             is_latest_version: true
             is_stable_version: true
+            is_gts_driver: true
           - driver_version: 535
             is_latest_driver: true
+          #- major_version: 39
+          #  is_latest_version: true
+          #  is_stable_version: false
+          #  is_gts_version: false
         exclude:
           # There is no Fedora 37 version of sericea
           # When F38 is added, sericea will automatically be built too
           - image_name: sericea
             major_version: 37
+          # There is no Fedora 37 or 38 version of onyx
+          - image_name: onyx
+            major_version: 37
+          - image_name: onyx
+            major_version: 38
+          - image_name: vauxite
+            major_version: 39
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
@@ -85,6 +107,12 @@ jobs:
              [[ "${{ matrix.is_latest_driver }}" == "true" ]]; then
               BUILD_TAGS+=("${TIMESTAMP}")
               BUILD_TAGS+=("latest")
+          fi
+
+          if [[ "${{ matrix.is_gtst_version }}" == "true" ]] && \
+             [[ "${{ matrix.is_latest_driver }}" == "true" ]]; then
+              BUILD_TAGS+=("gts-${TIMESTAMP}")
+              BUILD_TAGS+=("gts")
           fi
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,3 +220,12 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"
+
+  check:
+    name: Check all builds successful
+    runs-on: ubuntu-latest
+    needs: [push-ghcr]
+    steps:
+      - name: Exit
+        shell: bash
+        run: exit 0

--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,11 @@
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
 ARG BASE_IMAGE="ghcr.io/ublue-os/${IMAGE_NAME}-main"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
-FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}
+FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS nvidia
 
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-535}"
 
 COPY install.sh /tmp/install.sh
@@ -13,8 +13,9 @@ COPY post-install.sh /tmp/post-install.sh
 
 COPY --from=ghcr.io/ublue-os/akmods-nvidia:${FEDORA_MAJOR_VERSION}-${NVIDIA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
-RUN /tmp/install.sh
-RUN /tmp/post-install.sh
-RUN rm -rf /tmp/* /var/*
-RUN ostree container commit
-RUN mkdir -p /var/tmp && chmod -R 1777 /tmp /var/tmp
+RUN /tmp/install.sh && \
+    /tmp/post-install.sh && \
+    rm -rf /tmp/* /var/*
+
+RUN ostree container commit && \
+    mkdir -p /var/tmp && chmod -R 1777 /tmp /var/tmp

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Nvidia
 
-This repository has served it's purpose. We salute your service to the Linux desktop.
+[![build-ublue](https://github.com/ublue-os/nvidia/actions/workflows/build.yml/badge.svg)](https://github.com/ublue-os/nvidia/actions/workflows/build.yml)
 
-These images are now being built out of [ublue-os/akmods](https://github.com/ublue-os/akmods) and [ublue-os/main](https://github.com/ublue-os/main).
+The purpose of these images is to provide [community Fedora images](https://github.com/ublue-os/main) with Nvidia drivers built-in. This approach can lead to greater reliability as failures can be caught at the build level instead of the client machine. This also allows for individual sets of images for each series of Nvidia drivers, allowing users to remain current with their OS but on an older, known working driver. Performance regression with a recent driver update? Reboot into a known-working driver after one command. That's the goal!
+
+# Documentation
+
+- [Main website and documentation](https://universal-blue.org)
+- [Documentation for these images](https://universal-blue.org/images/nvidia)
+- [Installation](https://universal-blue.org/installation/) - follow this for clean installation
+- [Rebase instructions](https://universal-blue.org/images/) - follow this if you want to switch to another image.

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,19 @@
 
 set -ouex pipefail
 
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
+if [[ "${FEDORA_MAJOR_VERSION}" -le 38 ]]; then
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
+else
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
+fi
+
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F39 launches, bump to 40
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
 
 rpm-ostree install \
     /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
@@ -19,5 +31,9 @@ fi
 
 rpm-ostree install \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda-,devel-,kmodsrc-,power-}${NVIDIA_FULL_VERSION} \
+    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
     nvidia-container-toolkit nvidia-vaapi-driver supergfxctl ${VARIANT_PKGS} \
     /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION
Builds `*-nvidia` images from the nvidia repo instead of main repo.

Adds things which had been added in main repo during the interim period.
- gts tagging
- vesion F39 (commented out temporarily)
- onyx variant
- single rpmfusion mirror for CI builds