### PR TITLE
feat: Generate image info

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,15 +5,19 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS nvidia
 
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
+ARG IMAGE_VENDOR="ublue-os"
+ARG IMAGE_FLAVOR="${IMAGE_FLAVOR:-nvidia}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-535}"
 
+COPY image-info.sh /tmp/image-info.sh
 COPY install.sh /tmp/install.sh
 COPY post-install.sh /tmp/post-install.sh
 
 COPY --from=ghcr.io/ublue-os/akmods-nvidia:${FEDORA_MAJOR_VERSION}-${NVIDIA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
-RUN /tmp/install.sh && \
+RUN /tmp/image-info.sh && \
+    /tmp/install.sh && \
     /tmp/post-install.sh && \
     rm -rf /tmp/* /var/*
 

--- a/image-info.sh
+++ b/image-info.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -oue pipefail
+
+IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+
+case $FEDORA_MAJOR_VERSION in
+  38)
+    IMAGE_TAG="latest"
+    ;;
+  *)
+    IMAGE_TAG="$FEDORA_MAJOR_VERSION"
+    ;;
+esac
+
+touch $IMAGE_INFO
+cat > $IMAGE_INFO <<EOF
+{
+  "image-name": "$IMAGE_NAME",
+  "image-flavor": "$IMAGE_FLAVOR",
+  "image-vendor": "$IMAGE_VENDOR",
+  "image-ref": "$IMAGE_REF",
+  "image-tag": "$IMAGE_TAG",
+  "fedora-version": "$FEDORA_MAJOR_VERSION"
+}
+EOF


### PR DESCRIPTION
Provides a useful reference for the state of the current installed image that can be utilized via ublue update for auto-signing or in scripts to determine what changes to make and exclude

Also ships jq for parsing generated image information

For example...

`jq '."image-flavor"' /usr/share/ublue-os/image-info.json`

... would print the flavor of the image (I.E. nvidia)