### PR TITLE
fix: use new akmods-nvidia:main-RELEASE tag structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   push-ghcr:
-    name: Build and push image
+    name: nvidia image
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ COPY image-info.sh /tmp/image-info.sh
 COPY install.sh /tmp/install.sh
 COPY post-install.sh /tmp/post-install.sh
 
-COPY --from=ghcr.io/ublue-os/akmods-nvidia:${FEDORA_MAJOR_VERSION}-${NVIDIA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
+COPY --from=ghcr.io/ublue-os/akmods-nvidia:main-${FEDORA_MAJOR_VERSION}-${NVIDIA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
 RUN /tmp/image-info.sh && \
     /tmp/install.sh && \


### PR DESCRIPTION
This was missed when https://github.com/ublue-os/akmods/pull/71 was completed.

Also, shortened workflow job name for easier reading in github UI