### PR TITLE
feat: enable ublue-nvctk-cdi.service by default

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -4,6 +4,7 @@ set -ouex pipefail
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-toolkit}.repo
 
+systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 ln -s /usr/bin/ld.bfd /etc/alternatives/ld
 ln -s /etc/alternatives/ld /usr/bin/ld


### PR DESCRIPTION
We added this service to generate nvidia device definitions for container toolkit, but it isn't enabling by default like it should.

This corrects that.