### PR TITLE
chore: restore default rpmfusion mirror behavior

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,14 +8,6 @@ else
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 fi
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
-# after F39 launches, bump to 40
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
-    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
-fi
-
 rpm-ostree install \
     /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
@@ -34,6 +26,3 @@ rpm-ostree install \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
     nvidia-container-toolkit nvidia-vaapi-driver supergfxctl ${VARIANT_PKGS} \
     /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
-
-# reset forced use of single rpmfusion mirror
-rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION
Ah while back, I made a change to akmods/main/nvidia repos to force them to use the same rpmfusion mirror during builds (this gets reset to defaults for resulting images).

This is problematic for F39, since, at the least, it will require a path change due to F39 promoting from "development" to "release".

Only merge after https://github.com/ublue-os/main/pull/413 is resolved.