### PR TITLE
chore(ci): pin to single berkley mirror

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,14 @@ else
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 fi
 
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
+
 rpm-ostree install \
     /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
@@ -26,3 +34,6 @@ rpm-ostree install \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
     nvidia-container-toolkit nvidia-vaapi-driver supergfxctl ${VARIANT_PKGS} \
     /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION
This consistently pins the build to the same mirror so jobs running on different runners should have the same set of packages to consistently succeed/fail.

This can't succeed until we get a solid build after the merge of https://github.com/ublue-os/main/pull/463