### PR TITLE
fix: remove dangling `ld` symlink

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -6,8 +6,6 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,nvidia-
 
 systemctl enable ublue-nvctk-cdi.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
-ln -s /usr/bin/ld.bfd /etc/alternatives/ld
-ln -s /etc/alternatives/ld /usr/bin/ld
 
 if [[ "${IMAGE_NAME}" == "sericea" ]]; then
     mv /etc/sway/environment{,.orig}


### PR DESCRIPTION
This symlink was part of an old workaround but breaks ability of downstreams to layer binutils, gcc, etc.

Fixes: #188