### PR TITLE
feat: Make supergfxctl optional based on IMAGE_NAME

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,9 +25,9 @@ rpm-ostree install \
 source /tmp/akmods-rpms/kmods/nvidia-vars.${NVIDIA_MAJOR_VERSION}
 
 if [[ "${IMAGE_NAME}" == "kinoite" ]]; then
-    VARIANT_PKGS="supergfxctl-plasmoid"
+    VARIANT_PKGS="supergfxctl-plasmoid supergfxctl"
 elif [[ "${IMAGE_NAME}" == "silverblue" ]]; then
-    VARIANT_PKGS="gnome-shell-extension-supergfxctl-gex"
+    VARIANT_PKGS="gnome-shell-extension-supergfxctl-gex supergfxctl"
 else
     VARIANT_PKGS=""
 fi
@@ -35,7 +35,7 @@ fi
 rpm-ostree install \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda-,devel-,kmodsrc-,power-}${NVIDIA_FULL_VERSION} \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
-    nvidia-container-toolkit nvidia-vaapi-driver supergfxctl ${VARIANT_PKGS} \
+    nvidia-container-toolkit nvidia-vaapi-driver ${VARIANT_PKGS} \
     /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
 
 if [ -n "${RPMFUSION_MIRROR}" ]; then


### PR DESCRIPTION
Switcheroo can do this same task, so we can move supergfxctl to the image-specific change list. Downstream can pass another value to IMAGE_NAME to prevent any part of supergfxctl from being installed.

Could also move this to a separate true/false flag, though that may be less clean.